### PR TITLE
Rate Limiter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ app.use(morganMiddleware);
 const limiter = rateLimit({
     windowMs: Number(process.env.RATE_LIMIT_WINDOW) * 60 * 1000,
     max: Number(process.env.RATE_LIMIT_MAX_REQUESTS),
+    skip: req => req.path === '/auth/me',
 });
 app.use('/api/', limiter);
 


### PR DESCRIPTION
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R42): Added a `skip` option to the rate limiter to exclude the `/auth/me` endpoint from rate limiting.